### PR TITLE
Adding bigendian support

### DIFF
--- a/backends/golang/init.go
+++ b/backends/golang/init.go
@@ -2,19 +2,25 @@ package golang
 
 import (
 	"flag"
+	"fmt"
 	"go/format"
 
 	"github.com/andyleap/gencode/schema"
 )
 
 type GolangBackend struct {
-	Package string
-	Unsafe  bool
+	Package   string
+	Unsafe    bool
+	BigEndian bool
 }
 
 func (gb *GolangBackend) Generate(s *schema.Schema) (string, error) {
 	w := &Walker{}
 	w.Unsafe = gb.Unsafe
+	w.BigEndian = gb.BigEndian
+	if w.Unsafe && w.BigEndian {
+		return "", fmt.Errorf("Unsafe and BigEndian incompatible")
+	}
 	def, err := w.WalkSchema(s, gb.Package)
 	if err != nil {
 		return "", err
@@ -30,6 +36,7 @@ func (gb *GolangBackend) Flags() *flag.FlagSet {
 	flags := flag.NewFlagSet("Go", flag.ExitOnError)
 	flags.StringVar(&gb.Package, "package", "main", "package to build the gencode system for")
 	flags.BoolVar(&gb.Unsafe, "unsafe", false, "Generate faster, but unsafe code")
+	flags.BoolVar(&gb.BigEndian, "bigendian", false, "Generate bigendian code, incompatible with unsafe.")
 	return flags
 }
 

--- a/backends/golang/schema.go
+++ b/backends/golang/schema.go
@@ -11,18 +11,19 @@ type Walker struct {
 	Offset    int
 	IAdjusted bool
 	Unsafe    bool
+	BigEndian bool
 }
 
 func (w *Walker) WalkSchema(s *schema.Schema, Package string) (parts *StringBuilder, err error) {
 	parts = &StringBuilder{}
 	parts.Append(fmt.Sprintf(`package %s
-	
+
 	import (
 		"unsafe"
 		"io"
 		"time"
 	)
-	
+
 	var (
 		_ = unsafe.Sizeof(0)
 		_ = io.ReadFull


### PR DESCRIPTION
currently ints and floats encoded in little endian.
in some cases it is preferred to have bigendian (for example for encoding keys for leveldb like databases).

here is a small patch that adds flag to generate bigendian encoding.
