### PR TITLE
[Enhancement] 'outfile' flag to override backend's generated filename

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,10 +28,13 @@ func main() {
 
 	flags := backend.Flags()
 
-	SchemaFile := ""
-	Debug := false
+	var (
+		SchemaFile, OutFile string
+		Debug               = false
+	)
 
 	flags.StringVar(&SchemaFile, "schema", "", "Schema file to process")
+	flags.StringVar(&OutFile, "out", "", "Filename for the generated code (optional)")
 	flags.BoolVar(&Debug, "debug", false, "Pretty print the resulting schema defs")
 
 	flags.Parse(os.Args[2:])
@@ -66,7 +69,12 @@ func main() {
 		log.Fatalf("Error generating output: %s", err)
 	}
 
-	err = ioutil.WriteFile(backend.GeneratedFilename(SchemaFile), []byte(code), 0666)
+	// Override generated file's filename.
+	outf := OutFile
+	if OutFile == "" {
+		outf = backend.GeneratedFilename(SchemaFile)
+	}
+	err = ioutil.WriteFile(outf, []byte(code), 0666)
 
 	if err != nil {
 		log.Fatalf("Error writing output file: %s", err)


### PR DESCRIPTION
I found the ".gen.go" suffix convention not really working with some of my projects, so, added an optional command line flag that'll take an output file name. If left blank, it'll use the backend's file name generator.

Eg:
Default backend file name
```go
gencode go -schema myschema // Generates myschema.gen.go
```

Override file name
```go
gencode go -schema myschema -out models.go // Generates models.go
```