### PR TITLE
Added support for optional cop-over struct tags in schema

### DIFF
--- a/backends/golang/struct.go
+++ b/backends/golang/struct.go
@@ -205,7 +205,17 @@ func (w *Walker) WalkFieldDef(s *schema.Field) (parts *StringBuilder, err error)
 	if err != nil {
 		return nil, err
 	}
-	parts.Join(subp)
+
+	// Optional struct tag.
+	if s.Tag != "" {
+		parts.Append(subp.String())
+		t := &StringBuilder{}
+		t.Append(fmt.Sprintf(`%s `, s.Tag))
+		parts.Join(t)
+	} else {
+		parts.Join(subp)
+	}
+
 	return
 }
 

--- a/schema/parser_test.go
+++ b/schema/parser_test.go
@@ -48,3 +48,19 @@ struct group {
 
 	//	def.Generate(os.Stdout, "test")
 }
+
+func TestParserStructTag(t *testing.T) {
+	g := MakeGrammar()
+
+	s, err := g.ParseString(`
+struct Person {
+	name string ` + "`json:\"name\"`" + `
+	age int32
+}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = (s.(*Schema))
+
+	//	def.Generate(os.Stdout, "test")
+}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -28,6 +28,7 @@ type ResolveType interface {
 
 type Field struct {
 	Name string
+	Tag  string
 	Type Type
 }
 


### PR DESCRIPTION
In a reasonably large codebase, structs generated by gencode from schema may be shared by various parts. A simple example would first populating a struct with a json.Unmarshal and then marshalling with struct.EncodeMsg. Here, the first step may require json tags.

This PR adds support for optional, copy-over struct tags in the schema definitions.


eg:
```go
struct Person {
	Name    string   `json:"name" redis:"name"`
	Age     int
}
```

Generated struct in x.gen.go
```go
struct Person type {
	Name    string   `json:"name" redis:"name"`
	Age     int
}
```

fixes #15 