### PR TITLE
Fixed: unit tests, Printf-style args, package names

### DIFF
--- a/backends/golang/testdata/array.schema.golden.go
+++ b/backends/golang/testdata/array.schema.golden.go
@@ -70,10 +70,10 @@ func (d *Array) Size() (s uint64) {
 
 		}
 
-		for k := range d.D {
+		for k0 := range d.D {
 
 			{
-				s += d.D[k].Size()
+				s += d.D[k0].Size()
 			}
 
 		}
@@ -140,17 +140,17 @@ func (d *Array) Marshal(buf []byte) ([]byte, error) {
 			i++
 
 		}
-		for k := range d.C {
+		for k0 := range d.C {
 
 			{
 
-				buf[i+0+0] = byte(d.C[k] >> 0)
+				buf[i+0+0] = byte(d.C[k0] >> 0)
 
-				buf[i+1+0] = byte(d.C[k] >> 8)
+				buf[i+1+0] = byte(d.C[k0] >> 8)
 
-				buf[i+2+0] = byte(d.C[k] >> 16)
+				buf[i+2+0] = byte(d.C[k0] >> 16)
 
-				buf[i+3+0] = byte(d.C[k] >> 24)
+				buf[i+3+0] = byte(d.C[k0] >> 24)
 
 			}
 
@@ -174,10 +174,10 @@ func (d *Array) Marshal(buf []byte) ([]byte, error) {
 			i++
 
 		}
-		for k := range d.D {
+		for k0 := range d.D {
 
 			{
-				nbuf, err := d.D[k].Marshal(buf[i+0:])
+				nbuf, err := d.D[k0].Marshal(buf[i+0:])
 				if err != nil {
 					return nil, err
 				}
@@ -240,11 +240,11 @@ func (d *Array) Unmarshal(buf []byte) (uint64, error) {
 		} else {
 			d.C = make([]int32, l)
 		}
-		for k := range d.C {
+		for k0 := range d.C {
 
 			{
 
-				d.C[k] = 0 | (int32(buf[i+0+0]) << 0) | (int32(buf[i+1+0]) << 8) | (int32(buf[i+2+0]) << 16) | (int32(buf[i+3+0]) << 24)
+				d.C[k0] = 0 | (int32(buf[i+0+0]) << 0) | (int32(buf[i+1+0]) << 8) | (int32(buf[i+2+0]) << 16) | (int32(buf[i+3+0]) << 24)
 
 			}
 
@@ -274,10 +274,10 @@ func (d *Array) Unmarshal(buf []byte) (uint64, error) {
 		} else {
 			d.D = make([]Nested, l)
 		}
-		for k := range d.D {
+		for k0 := range d.D {
 
 			{
-				ni, err := d.D[k].Unmarshal(buf[i+0:])
+				ni, err := d.D[k0].Unmarshal(buf[i+0:])
 				if err != nil {
 					return 0, err
 				}
@@ -332,10 +332,10 @@ func (d *Nested) Size() (s uint64) {
 
 		}
 
-		for k := range d.B {
+		for k0 := range d.B {
 
 			{
-				l := uint64(len(d.B[k]))
+				l := uint64(len(d.B[k0]))
 
 				{
 
@@ -407,10 +407,10 @@ func (d *Nested) Marshal(buf []byte) ([]byte, error) {
 			i++
 
 		}
-		for k := range d.B {
+		for k0 := range d.B {
 
 			{
-				l := uint64(len(d.B[k]))
+				l := uint64(len(d.B[k0]))
 
 				{
 
@@ -425,7 +425,7 @@ func (d *Nested) Marshal(buf []byte) ([]byte, error) {
 					i++
 
 				}
-				copy(buf[i+0:], d.B[k])
+				copy(buf[i+0:], d.B[k0])
 				i += l
 			}
 
@@ -485,7 +485,7 @@ func (d *Nested) Unmarshal(buf []byte) (uint64, error) {
 		} else {
 			d.B = make([]string, l)
 		}
-		for k := range d.B {
+		for k0 := range d.B {
 
 			{
 				l := uint64(0)
@@ -504,7 +504,7 @@ func (d *Nested) Unmarshal(buf []byte) (uint64, error) {
 					l = t
 
 				}
-				d.B[k] = string(buf[i+0 : i+0+l])
+				d.B[k0] = string(buf[i+0 : i+0+l])
 				i += l
 			}
 

--- a/backends/golang/testdata/int_test.go
+++ b/backends/golang/testdata/int_test.go
@@ -45,7 +45,7 @@ func testInt64(t *testing.T, x int64) {
 		t.Errorf("%d: Unmarshal and Marshal report different # bytes: %d vs. %d", x, n, len(buf))
 	}
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("%d: Unmarshal = %d; want %d", got, want)
+		t.Errorf("%d: Unmarshal = %d; want %d", x, got, want)
 	}
 }
 
@@ -73,7 +73,7 @@ func testUint64(t *testing.T, x uint64) {
 		t.Errorf("%d: Unmarshal and Marshal report different # bytes: %d vs. %d", x, n, len(buf))
 	}
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("%d: Unmarshal = %d; want %d", got, want)
+		t.Errorf("%d: Unmarshal = %d; want %d", x, got, want)
 	}
 }
 

--- a/bench/binary_test.go
+++ b/bench/binary_test.go
@@ -1,4 +1,4 @@
-package main
+package bench
 
 import (
 	"bytes"

--- a/bench/fixed.schema.gen.go
+++ b/bench/fixed.schema.gen.go
@@ -1,4 +1,4 @@
-package main
+package bench
 
 import (
 	"io"

--- a/bench/gencode_test.go
+++ b/bench/gencode_test.go
@@ -1,4 +1,4 @@
-package main
+package bench
 
 import (
 	"fmt"

--- a/bench/gob_test.go
+++ b/bench/gob_test.go
@@ -1,4 +1,4 @@
-package main
+package bench
 
 import (
 	"bytes"

--- a/bench/json_test.go
+++ b/bench/json_test.go
@@ -1,4 +1,4 @@
-package main
+package bench
 
 import (
 	"encoding/json"

--- a/bench/msgp_test.go
+++ b/bench/msgp_test.go
@@ -1,4 +1,4 @@
-package main
+package bench
 
 import (
 	"fmt"

--- a/bench/test.schema.gen.go
+++ b/bench/test.schema.gen.go
@@ -1,4 +1,4 @@
-package main
+package bench
 
 import (
 	"io"

--- a/bench/test.schema.gen_gen.go
+++ b/bench/test.schema.gen_gen.go
@@ -1,4 +1,4 @@
-package main
+package bench
 
 // NOTE: THIS FILE WAS PRODUCED BY THE
 // MSGP CODE GENERATION TOOL (github.com/tinylib/msgp)

--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ func main() {
 	}
 
 	if file == nil {
-		log.Fatalf("error opening file %s", file)
+		log.Fatalf("error opening file %s", SchemaFile)
 	}
 
 	s, err := schema.ParseSchema(file)


### PR DESCRIPTION
- fixed some Printf-style arguments where invalid param count and incorrect argument type passed in
- fixed unit tests from the last PR (mine - sorry!)
- changed the package name in "bench" directory from "main", for any CI systems that want to build all packages: as "main" package, compiler was expecting `int main()`